### PR TITLE
move comment section past document delimiter

### DIFF
--- a/policy/cluster/cert-manager.yaml
+++ b/policy/cluster/cert-manager.yaml
@@ -1,3 +1,4 @@
+---
 # Copyright YEAR The Jetstack cert-manager contributors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
----
 # Source: cert-manager/templates/templates.regular.out
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition


### PR DESCRIPTION
I know this is cargo culting but I am not sure what else to make of 
```
 importer [4] KNV2001: unmarshalerDecoder: Object 'Kind' is missing in 'null', error found in #4 byte of ...|null|..., bigger context ...|null|...                                                                                                                                                                                                                                         \
│                                                                                                                                                                                                                                                                                                                                                                                            
│ importer path: /repo/rev/policy/cluster/cert-manager.yaml                                 
```