### PR TITLE
Add kube-system namespace

### DIFF
--- a/policy/namespaces/kube-system/namespace.yaml
+++ b/policy/namespaces/kube-system/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kube-system


### PR DESCRIPTION
Anthos requires a namespace declaration https://cloud.google.com/anthos-config-management/docs/how-to/namespace-scoped-objects#namespace-config