### PR TITLE
Add 3 dedicated data nodes

### DIFF
--- a/policy/namespaces/default/e2e-monitor.yaml
+++ b/policy/namespaces/default/e2e-monitor.yaml
@@ -43,6 +43,42 @@ spec:
           requests:
             storage: 500Gi
         storageClassName: standard-wait
+  - name: data
+    count: 3
+    config:
+      node.master: false
+      node.store.allow_mmap: false
+    podTemplate:
+      spec:
+        initContainers:
+        - name: install-plugins
+          command:
+          - sh
+          - -c
+          - |
+            bin/elasticsearch-plugin install --batch repository-gcs
+        containers:
+        - name: elasticsearch
+          env:
+          - name: ES_JAVA_OPTS
+            value: -Xms16g -Xmx16g
+          resources:
+            requests:
+              memory: 32Gi
+              cpu: 18
+            limits:
+              memory: 32Gi
+              cpu: 18
+    volumeClaimTemplates:
+    - metadata:
+        name: elasticsearch-data
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 500Gi
+        storageClassName: standard-wait
   http:
     service:
       spec:


### PR DESCRIPTION
This PR adds 3 dedicated data nodes as some of the existing ones are approaching the low watermark which will prevent shard allocations:

```
> kbash e2e-monitor-es-md-nodes3-0
[root@e2e-monitor-es-md-nodes3-0 elasticsearch]# df -m
Filesystem     1M-blocks   Used Available Use% Mounted on
...
/dev/sdc          502941 419802     83123  84% /usr/share/elasticsearch/dat
``` 