### PR TITLE
Add ClusterRole and ClusterRoleBinding for ingress-nginx

### DIFF
--- a/policy/namespaces/ingress-nginx/nginx.yml
+++ b/policy/namespaces/ingress-nginx/nginx.yml
@@ -39,6 +39,98 @@ metadata:
   namespace: ingress-nginx
 data:
 ---
+# Source: ingress-nginx/templates/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+  name: ingress-nginx
+  namespace: ingress-nginx
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ''
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - update
+      - watch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ''
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - extensions
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+  - apiGroups:
+      - networking.k8s.io   # k8s 1.14+
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+# Source: ingress-nginx/templates/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+  name: ingress-nginx
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx
+    namespace: ingress-nginx
+---
 # Source: ingress-nginx/templates/controller-role.yaml
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -320,6 +412,89 @@ spec:
         - name: webhook-cert
           secret:
             secretName: ingress-nginx-admission
+---
+# Source: ingress-nginx/templates/admission-webhooks/validating-webhook.yaml
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  name: ingress-nginx-admission
+  namespace: ingress-nginx
+webhooks:
+  - name: validate.nginx.ingress.kubernetes.io
+    rules:
+      - apiGroups:
+          - extensions
+          - networking.k8s.io
+        apiVersions:
+          - v1beta1
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - ingresses
+    failurePolicy: Fail
+    clientConfig:
+      service:
+        namespace: ingress-nginx
+        name: ingress-nginx-controller-admission
+        path: /extensions/v1beta1/ingresses
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/clusterrole.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ingress-nginx-admission
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  namespace: ingress-nginx
+rules:
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - update
+---
+# Source: ingress-nginx/templates/admission-webhooks/job-patch/clusterrolebinding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ingress-nginx-admission
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade,post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+  labels:
+    helm.sh/chart: ingress-nginx-2.0.3
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/version: 0.32.0
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/component: admission-webhook
+  namespace: ingress-nginx
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ingress-nginx-admission
+subjects:
+  - kind: ServiceAccount
+    name: ingress-nginx-admission
+    namespace: ingress-nginx
 ---
 # Source: ingress-nginx/templates/admission-webhooks/job-patch/job-createSecret.yaml
 apiVersion: batch/v1


### PR DESCRIPTION
Since the recent reset of the e2e-monitor, the nginx-ingress-controller complains to not have cluster scope RBAC:

```
E0211 09:34:09.168000       6 reflector.go:178] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:160: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:ingress-nginx:ingress-nginx" ca
nnot list resource "configmaps" in API group "" at the cluster scope
E0211 09:34:14.498613       6 reflector.go:178] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:157: Failed to list *v1.Secret: secrets is forbidden: User "system:serviceaccount:ingress-nginx:ingress-nginx" cannot l
ist resource "secrets" in API group "" at the cluster scope
E0211 09:34:18.755871       6 reflector.go:178] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:159: Failed to list *v1.Service: services is forbidden: User "system:serviceaccount:ingress-nginx:ingress-nginx" cannot
 list resource "services" in API group "" at the cluster scope
E0211 09:34:19.475444       6 reflector.go:178] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:160: Failed to list *v1.ConfigMap: configmaps is forbidden: User "system:serviceaccount:ingress-nginx:ingress-nginx" ca
nnot list resource "configmaps" in API group "" at the cluster scope
E0211 09:34:21.813962       6 reflector.go:178] k8s.io/ingress-nginx/internal/ingress/controller/store/store.go:158: Failed to list *v1.Endpoints: endpoints is forbidden: User "system:serviceaccount:ingress-nginx:ingress-nginx" can
not list resource "endpoints" in API group "" at the cluster scope
I0211 09:34:39.114129       6 main.go:179] Received SIGTERM, shutting down                                         
I0211 09:34:39.114187       6 nginx.go:391] Shutting down controller queues                                        
I0211 09:34:39.114215       6 status.go:118] updating status of Ingress rules (remove)                             
E0211 09:34:39.114363       6 store.go:172] timed out waiting for caches to sync                                   
I0211 09:34:39.131243       6 status.go:137] removing address from ingress status ([34.142.29.8])                                                                                                                                      
I0211 09:34:39.131319       6 nginx.go:399] Stopping admission controller                                          
I0211 09:34:39.131327       6 nginx.go:407] Stopping NGINX process                                                 
2022/02/11 09:34:39 [notice] 38#38: signal process started                                                         
2022/02/11 09:34:39 [error] 38#38: open() "/tmp/nginx.pid" failed (2: No such file or directory)                                                                                                                                       
nginx: [error] open() "/tmp/nginx.pid" failed (2: No such file or directory)                                       
I0211 09:34:39.138923       6 main.go:183] Error during shutdown: exit status 1                                    
I0211 09:34:39.138950       6 main.go:187] Handled quit, awaiting Pod deletion                                     
E0211 09:34:40.114536       6 store.go:186] timed out waiting for caches to sync                                   
I0211 09:34:40.114726       6 nginx.go:307] Starting NGINX process                                                 
I0211 09:34:40.114892       6 leaderelection.go:242] attempting to acquire leader lease  ingress-nginx/ingress-controller-leader-nginx...                                                                                              
E0211 09:34:40.115124       6 queue.go:78] queue has been shutdown, failed to enqueue: &ObjectMeta{Name:initial-sync,GenerateName:,Namespace:,SelfLink:,UID:,ResourceVersion:,Generation:0,CreationTimestamp:0001-01-01 00:00:00 +0000 
UTC,DeletionTimestamp:<nil>,DeletionGracePeriodSeconds:nil,Labels:map[string]string{},Annotations:map[string]string{},OwnerReferences:[]OwnerReference{},Finalizers:[],ClusterName:,ManagedFields:[]ManagedFieldsEntry{},}
I0211 09:34:40.115294       6 nginx.go:327] Starting validation webhook on :8443 with keys /usr/local/certificates/cert /usr/local/certificates/key                                                                                    
E0211 09:34:40.115313       6 nginx.go:329] http: Server closed                                                    
I0211 09:34:40.121854       6 status.go:86] new leader elected: ingress-nginx-controller-564768b55d-6fj8s                                                                                                                              
I0211 09:34:49.139183       6 main.go:190] Exiting with 1  
```

This commit just updates `policy/namespaces/ingress-nginx/nginx.yml` with the content of https://github.com/kubernetes/ingress-nginx/blob/ingress-nginx-2.0.3/deploy/static/provider/cloud/deploy.yaml.

I applied this updated manifest and it looks good now.

I'm not sure how it worked before. We will have to call on the memory of @\barkbay when he is back.
